### PR TITLE
Mark repository as no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE: This repository is no longer supported or updated by Koru Kids. See [heroku-buildpack-apt](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-apt) instead.**
+
 Heroku buildpack: geo
 =====================
 


### PR DESCRIPTION
Now that we've switched to using the heroku-buildpack-apt for installing libgeos-dev, retire this project.

After this is merged we should also:

- [ ] Archive repository
- [ ] Update GitHub repository description